### PR TITLE
Fix 비동기함수 호출했을때 에러가 발생한 경우 돌아가기 클릭 후 다시 호출하면 캐싱된 값때문에 호출대신 그냥 에러창이 뜨는…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="upgrade-insecure-requests"
+      charset="UTF-8"
+    />
     <link rel="icon" type="image/svg+xml" href="./searchIcon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>키워드 홈페이지</title>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,10 +11,7 @@ export type RootState = ReturnType<typeof store.getState>;
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60 * 5,
-      gcTime: 1000 * 60 * 5,
       retry: 0,
-     
     },
   },
 });


### PR DESCRIPTION
비동기함수 호출했을때 에러가 발생한 경우 돌아가기 클릭 후 다시 호출하면 캐싱된 값때문에 호출대신 그냥 에러창이 뜨는이슈 해결 +  react-query 캐싱 제거